### PR TITLE
Add in-depth private ip filtering

### DIFF
--- a/cli/src/commands/authorities.rs
+++ b/cli/src/commands/authorities.rs
@@ -1,4 +1,4 @@
-use crate::utils::build_swarm;
+use crate::utils::{build_swarm, is_public_address};
 use codec::Decode;
 use futures::FutureExt;
 use futures::StreamExt;
@@ -493,14 +493,27 @@ impl AuthorityDiscovery {
                                 });
 
                             // Dial the peer so the identify protocol can run.
+                            // Only add public addresses to prevent connecting to private IPs.
                             if !self.peer_info.contains_key(&peer_id) {
+                                let mut has_public_addr = false;
                                 for addr in &addresses {
-                                    self.swarm
-                                        .behaviour_mut()
-                                        .discovery
-                                        .add_address(&peer_id, addr.clone());
+                                    if is_public_address(addr) {
+                                        self.swarm
+                                            .behaviour_mut()
+                                            .discovery
+                                            .add_address(&peer_id, addr.clone());
+                                        has_public_addr = true;
+                                    } else {
+                                        log::debug!(
+                                            "Skipping private address for peer {}: {}",
+                                            peer_id,
+                                            addr
+                                        );
+                                    }
                                 }
-                                let _ = self.swarm.dial(peer_id);
+                                if has_public_addr {
+                                    let _ = self.swarm.dial(peer_id);
+                                }
                             }
 
                             log::debug!(
@@ -586,6 +599,42 @@ impl AuthorityDiscovery {
                             }
                         };
                     }
+
+                    // Filter out private addresses learned from Kademlia peer exchange.
+                    BehaviourEvent::Discovery(KademliaEvent::RoutablePeer { peer, address }) => {
+                        if !is_public_address(&address) {
+                            log::debug!(
+                                "Removing private address from RoutablePeer {}: {}",
+                                peer,
+                                address
+                            );
+                            self.swarm
+                                .behaviour_mut()
+                                .discovery
+                                .remove_address(&peer, &address);
+                        }
+                    }
+
+                    BehaviourEvent::Discovery(KademliaEvent::RoutingUpdated {
+                        peer,
+                        addresses,
+                        ..
+                    }) => {
+                        for addr in addresses.iter() {
+                            if !is_public_address(addr) {
+                                log::debug!(
+                                    "Removing private address from RoutingUpdated {}: {}",
+                                    peer,
+                                    addr
+                                );
+                                self.swarm
+                                    .behaviour_mut()
+                                    .discovery
+                                    .remove_address(&peer, addr);
+                            }
+                        }
+                    }
+
                     _ => (),
                 }
             }

--- a/cli/src/commands/identity.rs
+++ b/cli/src/commands/identity.rs
@@ -330,7 +330,7 @@ pub async fn fetch_identity_names(
     let mut missing_stashes: Vec<[u8; 32]> = Vec::new();
     for (stash, hex_key) in unique_stashes.iter().zip(identity_keys.iter()) {
         if let Some(value) = identity_values.get(hex_key) {
-            if let Some(display) = decode_display_name(value) 
+            if let Some(display) = decode_display_name(value) {
                 if let Some(auths) = stash_to_auth.get(stash) {
                     for auth in auths {
                         names.insert(*auth, display.clone());

--- a/cli/src/filtered_transport.rs
+++ b/cli/src/filtered_transport.rs
@@ -1,0 +1,101 @@
+// Copyright 2024 Zondax GmbH
+// This file is dual-licensed as Apache-2.0 or GPL-3.0.
+// see LICENSE for license details.
+
+//! Filtered transport wrapper that blocks connections to private IP addresses.
+
+use ip_network::IpNetwork;
+use libp2p::{
+    core::transport::{DialOpts, ListenerId, TransportError, TransportEvent},
+    multiaddr::Protocol,
+    Multiaddr, Transport,
+};
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+/// Wrapper transport that filters out private IP addresses before dialing.
+#[derive(Debug, Clone)]
+pub struct FilteredTransport<T> {
+    inner: T,
+}
+
+impl<T> FilteredTransport<T> {
+    /// Create a new filtered transport wrapping the given transport.
+    pub fn new(inner: T) -> Self {
+        Self { inner }
+    }
+}
+
+/// Check if an address is a private/non-global IP address.
+fn is_private_address(addr: &Multiaddr) -> bool {
+    for protocol in addr.iter() {
+        match protocol {
+            Protocol::Ip4(ip) => {
+                let network = IpNetwork::from(ip);
+                if !network.is_global() {
+                    log::debug!("Blocking private IPv4 address: {}", ip);
+                    return true;
+                }
+            }
+            Protocol::Ip6(ip) => {
+                let network = IpNetwork::from(ip);
+                if !network.is_global() {
+                    log::debug!("Blocking private IPv6 address: {}", ip);
+                    return true;
+                }
+            }
+            // DNS addresses need resolution - we allow them
+            // (the resolved IP will be checked by the underlying transport if needed)
+            Protocol::Dns(_) | Protocol::Dns4(_) | Protocol::Dns6(_) => {
+                // Allow DNS - will be resolved later
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+impl<T> Transport for FilteredTransport<T>
+where
+    T: Transport,
+    T::Error: 'static,
+{
+    type Output = T::Output;
+    type Error = T::Error;
+    type ListenerUpgrade = T::ListenerUpgrade;
+    type Dial = T::Dial;
+
+    fn listen_on(
+        &mut self,
+        id: ListenerId,
+        addr: Multiaddr,
+    ) -> Result<(), TransportError<Self::Error>> {
+        self.inner.listen_on(id, addr)
+    }
+
+    fn remove_listener(&mut self, id: ListenerId) -> bool {
+        self.inner.remove_listener(id)
+    }
+
+    fn dial(
+        &mut self,
+        addr: Multiaddr,
+        opts: DialOpts,
+    ) -> Result<Self::Dial, TransportError<Self::Error>> {
+        if is_private_address(&addr) {
+            return Err(TransportError::MultiaddrNotSupported(addr));
+        }
+        self.inner.dial(addr, opts)
+    }
+
+    fn poll(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+    ) -> Poll<TransportEvent<Self::ListenerUpgrade, Self::Error>> {
+        // SAFETY: We're not moving `inner`, just getting a pinned reference to it
+        let inner = unsafe { self.map_unchecked_mut(|s| &mut s.inner) };
+        inner.poll(cx)
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod commands;
+pub mod filtered_transport;
 pub mod utils;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -3,6 +3,7 @@
 // see LICENSE for license details.
 
 mod commands;
+mod filtered_transport;
 mod utils;
 
 use clap::Parser as ClapParser;

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -3,7 +3,9 @@
 // see LICENSE for license details.
 
 use ip_network::IpNetwork;
-use libp2p::{identity, multiaddr::Protocol, Multiaddr, PeerId, Swarm};
+use libp2p::{core::upgrade, identity, multiaddr::Protocol, Multiaddr, PeerId, Swarm, Transport};
+
+use crate::filtered_transport::FilteredTransport;
 use maxminddb::{geoip2::City, Reader as GeoIpReader};
 use primitive_types::H256;
 use std::error::Error;
@@ -120,19 +122,47 @@ pub async fn build_swarm(
 
     let tcp_config = libp2p::tcp::Config::new().nodelay(true);
 
+    // Build TCP transport with noise and yamux
+    let tcp_transport = libp2p::tcp::tokio::Transport::new(tcp_config.clone())
+        .upgrade(upgrade::Version::V1Lazy)
+        .authenticate(libp2p::noise::Config::new(&local_key).expect("noise config"))
+        .multiplex(libp2p::yamux::Config::default())
+        .boxed();
+
+    // Wrap with DNS resolution
+    let tcp_dns_transport = libp2p::dns::tokio::Transport::system(tcp_transport)
+        .expect("DNS transport")
+        .boxed();
+
+    // Wrap with our filter to block private IPs
+    let filtered_tcp = FilteredTransport::new(tcp_dns_transport).boxed();
+
+    // Build WebSocket transport
+    let ws_transport = libp2p::websocket::Config::new(
+        libp2p::dns::tokio::Transport::system(libp2p::tcp::tokio::Transport::new(tcp_config))
+            .expect("DNS for WS"),
+    )
+    .upgrade(upgrade::Version::V1Lazy)
+    .authenticate(libp2p::noise::Config::new(&local_key).expect("noise config ws"))
+    .multiplex(libp2p::yamux::Config::default())
+    .boxed();
+
+    // Wrap WebSocket with filter too
+    let filtered_ws = FilteredTransport::new(ws_transport).boxed();
+
+    // Combine transports
+    let transport = filtered_tcp
+        .or_transport(filtered_ws)
+        .map(|output, _| match output {
+            futures::future::Either::Left(o) => o,
+            futures::future::Either::Right(o) => o,
+        })
+        .boxed();
+
     let mut swarm = libp2p::SwarmBuilder::with_existing_identity(local_key)
         .with_tokio()
-        .with_tcp(
-            tcp_config,
-            libp2p::noise::Config::new,
-            libp2p::yamux::Config::default,
-        )
-        .expect("Can construct TCP; qed")
-        .with_dns()
-        .expect("Can construct DNS; qed")
-        .with_websocket(libp2p::noise::Config::new, libp2p::yamux::Config::default)
-        .await
-        .expect("Can construct WebSocket; qed")
+        .with_other_transport(|_key| transport)
+        .expect("Can construct transport; qed")
         .with_behaviour(|_key| Behaviour {
             notifications,
             peer_info,


### PR DESCRIPTION
Running the authority checks causes attempts to connect to private ips, leading to port scanning detection false positives. The filtering before tcp connections to the discovered peers is not enough and checks are also needed during DHT queries.